### PR TITLE
arg: providing extra argument to procstat file

### DIFF
--- a/src/procstat.h
+++ b/src/procstat.h
@@ -47,22 +47,26 @@ struct procstat_item;
 /**
  * @brief: stats formatter method
  * @param object registered with statistics
+ * @param arg registered with statistics
  * @param buffer to format object to
  * @param lenght of buffer
  * @param offset to return from beginning of buffer. This can be ignored in case statistics string
  * is large > 4K
  */
-typedef ssize_t (*procstats_formatter)(void *object, char *buffer, size_t length, off_t offset);
+typedef ssize_t (*procstats_formatter)(void *object, uint64_t arg, char *buffer, size_t length, off_t offset);
+
 
 /**
  * @brief registration parameter for simple value statistics
  * @name of statistics
  * @bject to be passed to the formatter.
+ * @arg to be passed together with object to formatter
  * @fmt data formatter
  */
 struct procstat_simple_handle {
 	const char 	    *name;
 	void 	 	    *object;
+	uint64_t 	    arg;
 	procstats_formatter fmt;
 };
 
@@ -118,7 +122,7 @@ int procstat_create_simple(struct procstat_context *context,
 			   size_t descriptors_len);
 
 #define DEFINE_PROCSTAT_FORMATTER(__type, __fmt, __fmt_name)\
-static inline ssize_t procstat_format_ ## __type ##_## __fmt_name(void *object, char *buffer, size_t len, off_t offset)\
+static inline ssize_t procstat_format_ ## __type ##_## __fmt_name(void *object, uint64_t arg, char *buffer, size_t len, off_t offset)\
 {\
 	return snprintf(buffer, len, __fmt, *((__type *)object));\
 }\
@@ -141,7 +145,7 @@ DEFINE_PROCSTAT_FORMATTER(u32, "%x\n", hex);
 #define DEFINE_PROCSTAT_SIMPLE_ATTRIBUTE(__type)\
 static inline int procstat_create_ ## __type(struct procstat_context *context, struct procstat_item *parent, const char *name, __type *object)\
 {\
-	struct procstat_simple_handle descriptor = {name, object, procstat_format_ ## __type ## _decimal};\
+	struct procstat_simple_handle descriptor = {name, object, 0UL, procstat_format_ ## __type ## _decimal};\
 	\
 	return procstat_create_simple(context, parent, &descriptor, 1);\
 }\
@@ -154,11 +158,11 @@ DEFINE_PROCSTAT_SIMPLE_ATTRIBUTE(u64);
  * get function to fetch object value
  */
 #define DEFINE_PROCSTAT_CUSTOM_FORMATTER(name, getter_function, __type, __fmt)\
-static inline ssize_t procstat_format_ ## __type ##_## name(void *object, char *buffer, size_t length, off_t offset)\
+static inline ssize_t procstat_format_ ## __type ##_## name(void *object, uint64_t arg, char *buffer, size_t length, off_t offset)\
 {\
 	__type out;\
 	\
-	getter_function((__type *)object, &out);\
+	getter_function((__type *)object, arg, &out);\
 	return snprintf(buffer, length, __fmt, out);\
 }\
 

--- a/test/test.c
+++ b/test/test.c
@@ -85,7 +85,7 @@ void inc_values_64(uint64_t *vals)
 }
 
 
-static void fetch_getter(uint16_t *object, uint16_t *out)
+static void fetch_getter(uint16_t *object, uint64_t arg, uint16_t *out)
 {
 	*out = *object;
 }
@@ -101,9 +101,9 @@ DEFINE_PROCSTAT_CUSTOM_FORMATTER(fetch, fetch_getter, uint16_t, "%u");
 static void create_multiple_simple_stats(struct procstat_item *root, uint32_t *value_32, uint64_t *value_64, uint16_t *val16)
 {
 	struct procstat_item *item;
-	struct procstat_simple_handle descriptors[] = {{"val_32", value_32, procstat_format_u32_decimal},
-						       {"val_64", value_64, procstat_format_u64_decimal},
-							"val_16", val16, procstat_format_uint16_t_fetch};
+	struct procstat_simple_handle descriptors[] = {{"val_32", value_32, 0, procstat_format_u32_decimal},
+						       {"val_64", value_64, 0, procstat_format_u64_decimal},
+							"val_16", val16, 0, procstat_format_uint16_t_fetch};
 	int error;
 
 	item = procstat_create_directory(context, root, "multiple-simple");


### PR DESCRIPTION
This is helpfull for custom formatters in order to share  "object"
between statistics, and yet differentiate several statistics by some other
argument.