### PR TITLE
histogram: allow to reset histogram measurement.

### DIFF
--- a/src/procstat.h
+++ b/src/procstat.h
@@ -275,13 +275,13 @@ typedef void (*percentiles_calculator)(uint32_t *histogram,
 
 #define MAX_SUPPORTED_PERCENTILE 20
 struct procstat_histogram_u32 {
-	uint64_t 			  sum;
-	uint64_t 			  count;
-	uint64_t 			  last;
-	int	 			  npercentile;
-	struct procstat_percentile_result percentile[MAX_SUPPORTED_PERCENTILE];
-	uint32_t 			  *histogram;
-	percentiles_calculator 		  compute_cb;
+	uint64_t				sum;
+	uint64_t				count;
+	uint64_t				last;
+	int					npercentile;
+	struct procstat_percentile_result	percentile[MAX_SUPPORTED_PERCENTILE];
+	uint32_t				*histogram;
+	percentiles_calculator			compute_cb;
 };
 
 /**

--- a/src/procstat.h
+++ b/src/procstat.h
@@ -278,6 +278,7 @@ struct procstat_histogram_u32 {
 	uint64_t				sum;
 	uint64_t				count;
 	uint64_t				last;
+	unsigned                                reset;
 	int					npercentile;
 	struct procstat_percentile_result	percentile[MAX_SUPPORTED_PERCENTILE];
 	uint32_t				*histogram;

--- a/test/test.c
+++ b/test/test.c
@@ -314,7 +314,7 @@ void create_histogram(void)
 		procstat_histogram_u32_add_point(&series, i);
 	}
 
-	printf("Obsefve values\n");
+	printf("Observe values\n");
 	getchar();
 
 	procstat_percentile_calculate(series.histogram, series.count, series.percentile, 5);
@@ -324,8 +324,22 @@ void create_histogram(void)
 	assert(series.percentile[3].value == 987136);
 	assert(series.percentile[4].value == 1003520);
 
-	procstat_remove_by_name(context, NULL, "hist");
+	printf("Now reset Histogram, and observe zeroed values\n");
+	getchar();
 
+	printf("press enter to submit new values\n");
+	getchar();
+
+	for (i = 0; i < 1000000; ++i) {
+		procstat_histogram_u32_add_point(&series, i);
+	}
+
+	printf("Observe values\n");
+	getchar();
+
+	printf("removing histogram\n");
+
+	procstat_remove_by_name(context, NULL, "hist");
 }
 
 static int procstat_control_set_u64(void *object, const char *buffer, size_t length, off_t offset)


### PR DESCRIPTION
This allows to reset histogram information, which is usefull when investigating scenario.
Reset is working by writing 1 to "reset" file that is provided with the dataset.

Signed-off-by: Shelly Kagan <shelly@lightbitslabs.com>