### PR TITLE
fuse: fix memory leak when "reading" statistics

### DIFF
--- a/src/procstat.c
+++ b/src/procstat.c
@@ -1087,6 +1087,7 @@ void fuse_release(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 	void *object = fi->fh;
 
 	free(object);
+	fuse_reply_err(req, 0);
 }
 
 static struct fuse_lowlevel_ops fops = {


### PR DESCRIPTION
At some point release function stoped from been called, because
we did not call reply method inside release. This caused that fure  "RELEASE"
and  "RELEASE DIR" commands were not called by kernel upon file and folder close.
This lead to "release" method not been called and memory leak