### PR TITLE
procstat_create_simple: do not dereference null file

### DIFF
--- a/src/procstat.c
+++ b/src/procstat.c
@@ -755,11 +755,11 @@ int procstat_create_simple(struct procstat_context *context,
 
 		file = create_file(context, (struct procstat_directory *)parent,
 				   descriptor->name, descriptor->object, descriptor->fmt);
-		file->arg = descriptor->arg;
 		if (!file) {
 			--i;
 			goto error_release;
 		}
+		file->arg = descriptor->arg;
 	}
 	return 0;
 error_release:


### PR DESCRIPTION
When file=create_file() returns NULL bail out without
dereferencing file, so error code is returned instead of segfaulting.
create_file() returns NULL e.g. when "name" contains prohibited chars.