### PR TITLE
procstat: dont include unregistered item in directory listing

### DIFF
--- a/src/procstat.c
+++ b/src/procstat.c
@@ -60,6 +60,7 @@ enum {
 	STATS_ENTRY_CONTROL	     = 1 << 3
 };
 
+#define ATTRIBUTES_TIMEOUT_SEC (60.0 * 60)
 #define DNAME_INLINE_LEN 32
 struct procstat_dynamic_name {
 	unsigned zero:8;
@@ -262,6 +263,7 @@ static void fuse_lookup(fuse_req_t req, fuse_ino_t parent_inode, const char *nam
 	}
 
 	fuse_entry.ino = (uintptr_t)item;
+	fuse_entry.attr_timeout = ATTRIBUTES_TIMEOUT_SEC;
 	fill_item_stats(context, item, &fuse_entry.attr);
 	pthread_mutex_unlock(&context->global_lock);
 	fuse_reply_entry(req, &fuse_entry);
@@ -284,7 +286,7 @@ static void fuse_getattr(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *
 
 	fill_item_stats(context, item, &stat);
 	pthread_mutex_unlock(&context->global_lock);
-	fuse_reply_attr(req, &stat, 1.0);
+	fuse_reply_attr(req, &stat, ATTRIBUTES_TIMEOUT_SEC);
 }
 
 static void fuse_opendir(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)

--- a/src/procstat.c
+++ b/src/procstat.c
@@ -358,6 +358,8 @@ static void fuse_readdir(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
 		size_t entry_size;
 		struct stat stat;
 
+		if (!item_registered(iter))
+			continue;
 		memset(&stat, 0, sizeof(stat));
 		fname = procstat_item_name(iter);
 		fill_item_stats(context, iter, &stat);

--- a/test/test.c
+++ b/test/test.c
@@ -295,9 +295,11 @@ static void test_create_multiple_dirs_and_files(struct procstat_item *root, uint
 	assert(item);
 	printf("Found file value-6!\n\n");
 
-	printf("Delete several directories outer-0s\n");
-
+	printf("Delete several directories outer-0s .. press any key before delete \n");
+	getchar();
 	procstat_remove_by_name(context, root, "outer-0");
+	printf("Deleted outer-0 Watch values under outer-0 directory should not be here!!!\n");
+	getchar();
 	item = procstat_create_directory(context, root, "outer-0");
 	assert(item);
 }


### PR DESCRIPTION
When item is unregistered, but still have some external references
as for example directory in listing, it is still present in the tree.
We dont want to report such item in directory listing as item is alredy unregistered
and is just waiting to be deleted
sasha/LBM1-3930