### PR TITLE
Sasha/procstat as module param

### DIFF
--- a/src/procstat.c
+++ b/src/procstat.c
@@ -89,7 +89,7 @@ struct procstat_file {
 	struct procstat_item	base;
 	void  	    		*private;
 	uint64_t		arg;
-	procstats_formatter  	writer;
+	procstats_formatter  	fmt;
 };
 
 struct procstat_control {
@@ -462,7 +462,7 @@ static void fuse_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off, st
 
 	file = fuse_inode_to_file(ino);
 	if (off == 0)
-		read_buffer->size = file->writer(file->private, file->arg, read_buffer->buffer, READ_BUFFER_SIZE);
+		read_buffer->size = file->fmt(file->private, file->arg, read_buffer->buffer, READ_BUFFER_SIZE);
 
 	if (off >= read_buffer->size) {
 		fuse_reply_buf(req, NULL, 0);
@@ -500,7 +500,7 @@ static void init_item(struct procstat_item *item, const char *name)
 
 static struct procstat_file *allocate_file_item(const char *name,
 					   	void *priv,
-						procstats_formatter callback)
+						procstats_formatter fmt)
 {
 	struct procstat_file *file;
 
@@ -510,7 +510,7 @@ static struct procstat_file *allocate_file_item(const char *name,
 
 	init_item(&file->base, name);
 	file->private = priv;
-	file->writer = callback;
+	file->fmt = fmt;
 	return file;
 }
 
@@ -590,7 +590,7 @@ static struct procstat_item *parent_or_root(struct procstat_context *context, st
 static struct procstat_file *create_file(struct procstat_context *context,
 					 struct procstat_directory *parent,
 					 const char *name, void *item,
-					 procstats_formatter callback)
+					 procstats_formatter fmt)
 {
 	struct procstat_file *file;
 	int error;
@@ -600,7 +600,7 @@ static struct procstat_file *create_file(struct procstat_context *context,
 		return NULL;
 	}
 
-	file = allocate_file_item(name, item, callback);
+	file = allocate_file_item(name, item, fmt);
 	if (!file) {
 		errno = ENOMEM;
 		return NULL;

--- a/src/procstat.h
+++ b/src/procstat.h
@@ -71,20 +71,6 @@ struct procstat_simple_handle {
 	procstats_formatter writer;
 };
 
-/**
- * control callback is called when writing somehing to control file
- */
-typedef int (*procstat_control_cb)(void *object, const char *buffer, size_t length, off_t offset);
-
-/**
- * @brief handle to register control interface, via which values can be written to procstat
- * and @callback will be deliveed to application
- */
-struct procstat_control_handle {
-	const char	    *name;
-	void 		    *object;
-	procstat_control_cb callback;
-};
 
 /**
  * @brief create statstics context and mount it on running machine under @mountpoint.
@@ -159,13 +145,7 @@ int procstat_create_simple(struct procstat_context *context,
 			   struct procstat_simple_handle *descriptors,
 			   size_t descriptors_len);
 
-/**
- * @brief creates control file write to which results in callback
- * to application
- */
-int procstat_create_control(struct procstat_context *context,
-			    struct procstat_item *parent,
-			    struct procstat_control_handle *descriptor);
+
 
 #define DEFINE_PROCSTAT_FORMATTER(__type, __fmt, __fmt_name)\
 static inline ssize_t procstat_format_ ## __type ##_## __fmt_name(void *object, uint64_t arg, char *buffer, size_t len)\

--- a/test/test.c
+++ b/test/test.c
@@ -405,6 +405,22 @@ void test_control(void)
 	procstat_remove(context, item);
 }
 
+
+void test_parameter(void)
+{
+	int value = 0;
+	int error;
+	error = procstat_create_int_parameter(context, NULL, "param", &value);
+	assert(!error);
+
+	printf("Write to control and read value");
+	getchar();
+	printf("Value is %d\n", value);
+	printf("press any key to continue\n");
+	getchar();
+	procstat_remove_by_name(context, NULL, "param");
+}
+
 int main(int argc, char **argv) {
 	struct procstat_item *item;
 	uint32_t values_32[10];
@@ -424,6 +440,7 @@ int main(int argc, char **argv) {
 
 	pthread_t inc_x_thread;
 	pthread_create(&inc_x_thread, NULL, fuse_loop, context);
+	test_parameter();
 	not_create_dir_with_slash();
 	test_create_dirs(context);
 	test_not_create_invalid_filename();

--- a/test/test.c
+++ b/test/test.c
@@ -367,7 +367,7 @@ void create_histogram(void)
 	procstat_remove_by_name(context, NULL, "hist");
 }
 
-static int procstat_control_set_u64(void *object, const char *buffer, size_t length, off_t offset)
+static ssize_t procstat_control_set_u64(void *object, uint64_t arg, char *buffer, size_t length)
 {
 	uint64_t *ptr = object;
 	uint64_t value;
@@ -384,7 +384,7 @@ void test_control(void)
 {
 	struct procstat_item *item;
 	int error;
-	struct procstat_control_handle control = {.name="set", .callback = procstat_control_set_u64};
+	struct procstat_simple_handle control = {.name="set", .writer = procstat_control_set_u64};
 
 	item = procstat_create_directory(context, procstat_root(context), "with_control");
 	assert(item);
@@ -395,7 +395,7 @@ void test_control(void)
 
 	control.object = &counter;
 
-	error = procstat_create_control(context, item, &control);
+	error = procstat_create_simple(context, item, &control, 1);
 	assert(!error);
 
 	printf("Write to control and read value");


### PR DESCRIPTION
procstat enchancements:
1) enable to use procstat as module param i.e. variables that can be set from shell 
2) refactor "control" variables to use module param attributes and remove uneeded structure
this Pr must go with changes in lwip to support removal of control structure.