### PR TITLE
Alex/resets in intervals

### DIFF
--- a/src/procstat.c
+++ b/src/procstat.c
@@ -970,6 +970,11 @@ error_remove_stat:
 	return -1;
 }
 
+void procstat_u64_series_set_reset_interval(struct procstat_series_u64 *series, int reset_interval)
+{
+	series->reset.reset_interval = reset_interval;
+}
+
 int procstat_create_multiple_u64_series(struct procstat_context *context,
 					struct procstat_item *parent,
 					struct procstat_series_u64_handle *descriptors,
@@ -1416,6 +1421,11 @@ int procstat_create_histogram_u32_series(struct procstat_context *context, struc
 fail_remove_stat:
 	procstat_remove(context, &series_stat->root.base);
 	return -1;
+}
+
+void procstat_histogram_u32_series_set_reset_interval(struct procstat_histogram_u32 *series, int reset_interval)
+{
+	series->reset.reset_interval = reset_interval;
 }
 
 struct procstat_item *procstat_lookup_item(struct procstat_context *context,

--- a/src/procstat.c
+++ b/src/procstat.c
@@ -1220,7 +1220,7 @@ static ssize_t procstat_fmt_u32_percentile(void *object, uint64_t arg, char *buf
 	uint32_t zero = 0;
 	uint32_t *data_ptr = NULL;
 
-	reset = __atomic_load_n(&series->reset, __ATOMIC_ACQUIRE);
+	reset = __atomic_load_n(&series->reset.reset_flag, __ATOMIC_ACQUIRE);
 	if (reset) {
 		data_ptr = &zero;
 	} else {
@@ -1230,19 +1230,21 @@ static ssize_t procstat_fmt_u32_percentile(void *object, uint64_t arg, char *buf
 	return procstat_format_u32_decimal(data_ptr, 0, buffer, length);
 }
 
+void clear_values_histogram(struct procstat_histogram_u32 *series)
+{
+	series->count = 0;
+	series->sum = 0;
+	series->last = 0;
+	memset(series->histogram, 0, PROCSTAT_PERCENTILE_ARR_NR * sizeof(*series->histogram));
+	__atomic_store_n(&series->reset.reset_flag, 0, __ATOMIC_RELEASE);
+}
 
 void procstat_histogram_u32_add_point(struct procstat_histogram_u32 *series, uint32_t value)
 {
-	unsigned reset;
-
-	reset = __atomic_load_n(&series->reset, __ATOMIC_RELAXED);
-	if (reset) {
-		series->count = 0;
-		series->sum = 0;
-		series->last = 0;
-		memset(series->histogram, 0, PROCSTAT_PERCENTILE_ARR_NR * sizeof(*series->histogram));
-		__atomic_store_n(&series->reset, 0, __ATOMIC_RELEASE);
+	if (is_reset(&series->reset)) {
+		clear_values_histogram(series);
 	}
+
 	++series->count;
 	series->sum += value;
 	series->last = value;
@@ -1255,36 +1257,41 @@ enum histogram_u32_series_type{
 	HISTOGRAM_COUNT = 1,
 	HISTOGRAM_LAST = 2,
 	HISTOGRAM_AVG = 3,
+	HISTOGRAM_RESET_INTERVAL = 4,
 };
 
 static ssize_t histogram_u32_series_read(void *object, uint64_t arg, char *buffer, size_t len)
 {
 	struct procstat_histogram_u32 *series = object;
 	enum histogram_u32_series_type type = arg;
-	unsigned reset;
-	uint64_t zero = 0;
 	uint64_t *data_ptr = NULL;
 	uint64_t data;
 	uint64_t count;
 
-	reset = __atomic_load_n(&series->reset, __ATOMIC_ACQUIRE);
-	count = *((volatile uint64_t *)&series->count);
+	if (is_reset(&series->reset)) {
+		clear_values_histogram(series);
+	}
+
 	switch (type) {
 	case HISTOGRAM_SUM:
-		data_ptr = (reset) ? &zero : &series->sum;
+		data_ptr = &series->sum;
 		goto write_var;
 	case HISTOGRAM_COUNT:
-		data_ptr = (reset) ? &zero : &series->count;
+		count = *((volatile uint64_t *)&series->count);
+		data_ptr = &series->count;
 		goto write_var;
 	case HISTOGRAM_LAST:
-		data_ptr = (reset) ? &zero : &series->last;
+		data_ptr = &series->last;
 		goto write_var;
 	case HISTOGRAM_AVG:
-		if (!count || reset)
+		count = *((volatile uint64_t *)&series->count);
+		if (!count)
 			goto write_zero;
-
 		data = series->sum / count;
 		data_ptr = &data;
+		goto write_var;
+	case HISTOGRAM_RESET_INTERVAL:
+		data_ptr = &series->reset.reset_interval;
 		goto write_var;
 	default:
 		return -1;
@@ -1305,8 +1312,22 @@ static ssize_t reset_histogram_u32_series(void *object, uint64_t arg, char *buff
 	if (control != 1)
 		return EINVAL;
 
-	__atomic_store_n(&series->reset, 1, __ATOMIC_RELAXED);
+	__atomic_store_n(&series->reset.reset_flag, 1, __ATOMIC_RELAXED);
 	return 1;
+}
+
+static ssize_t reset_interval_histogram_u32_series(void *object, uint64_t arg, char *buffer, size_t length)
+{
+	struct procstat_series *series_stat = object;
+	struct procstat_histogram_u32 *series = series_stat->private;
+	int32_t control;
+
+	control = strtoul(buffer, NULL, 10);
+	if (control < 0)
+		return EINVAL;
+
+	__atomic_store_n(&series->reset.reset_interval, control, __ATOMIC_RELAXED);
+	return 1; 
 }
 
 int procstat_create_histogram_u32_series(struct procstat_context *context, struct procstat_item *parent,
@@ -1314,13 +1335,17 @@ int procstat_create_histogram_u32_series(struct procstat_context *context, struc
 {
 	int i;
 	struct procstat_series *series_stat;
-	struct procstat_simple_handle control = {.name = "reset", .writer = reset_histogram_u32_series};
+	struct procstat_simple_handle control[] = {
+		{.name = "reset", .writer = reset_histogram_u32_series},
+		{.name = "reset_interval_sec", .writer = reset_interval_histogram_u32_series},
+	};
 	int error;
 	struct procstat_simple_handle descriptors[] = {
-		{"sum",    series, HISTOGRAM_SUM, histogram_u32_series_read},
-		{"count",  series, HISTOGRAM_COUNT, histogram_u32_series_read},
-		{"last",   series, HISTOGRAM_LAST, histogram_u32_series_read},
-		{"avg",    series, HISTOGRAM_AVG, histogram_u32_series_read},
+		{"sum",    			series, HISTOGRAM_SUM, histogram_u32_series_read},
+		{"count",  			series, HISTOGRAM_COUNT, histogram_u32_series_read},
+		{"last",   			series, HISTOGRAM_LAST, histogram_u32_series_read},
+		{"avg",    			series, HISTOGRAM_AVG, histogram_u32_series_read},
+		{"get_reset_interval_sec",  	series, HISTOGRAM_RESET_INTERVAL, histogram_u32_series_read},
 	};
 
 	parent = parent_or_root(context, parent);
@@ -1371,8 +1396,18 @@ int procstat_create_histogram_u32_series(struct procstat_context *context, struc
 		file->arg = i;
 	}
 
-	control.object = series_stat;
-	error = procstat_create_simple(context, &series_stat->root.base, &control, 1);
+	struct timespec cur_time;
+	if (clock_gettime(CLOCK_REALTIME, &cur_time) == 0) {
+		series->reset.last_reset_time = cur_time.tv_sec;
+	} else {
+		series->reset.last_reset_time = 0;
+	}
+	series->reset.reset_flag = 0;
+	series->reset.reset_interval = 0;
+
+	control[0].object = series_stat;
+	control[1].object = series_stat;
+	error = procstat_create_simple(context, &series_stat->root.base, control, 2);
 	if (error)
 		goto fail_remove_stat;
 

--- a/src/procstat.h
+++ b/src/procstat.h
@@ -313,14 +313,14 @@ typedef void (*percentiles_calculator)(uint32_t *histogram,
 
 #define MAX_SUPPORTED_PERCENTILE 20
 struct procstat_histogram_u32 {
-	uint64_t				sum;
-	uint64_t				count;
-	uint64_t				last;
-	unsigned                                reset;
-	int					npercentile;
+	uint64_t 				sum;
+	uint64_t 				count;
+	uint64_t 				last;
+	int 					npercentile;
 	struct procstat_percentile_result	percentile[MAX_SUPPORTED_PERCENTILE];
-	uint32_t				*histogram;
-	percentiles_calculator			compute_cb;
+	uint32_t 				*histogram;
+	percentiles_calculator 			compute_cb;
+	struct reset_info 			reset;
 };
 
 /**

--- a/src/procstat.h
+++ b/src/procstat.h
@@ -271,6 +271,12 @@ int procstat_create_start_end(struct procstat_context 	       *context,
 #define procstat_start_end_u64_handle(name, start_end)\
 	(struct procstat_start_end_handle){name, &start_end.start, &start_end.end, procstat_format_u64_decimal}
 
+struct reset_info {
+	uint64_t reset_interval;
+	uint64_t last_reset_time;
+	unsigned reset_flag;
+};
+
 /**
  * @brief registration parameter for series statistics. statistical analysis will be performed on values
  * submitted as series point. mean and variance will be calculated upon even point submittion
@@ -286,14 +292,14 @@ struct procstat_series_u64_handle {
 
 
 struct procstat_series_u64 {
-	uint64_t sum;
-	uint64_t count;
-	uint64_t min;
-	uint64_t max;
-	uint64_t last;
-	uint64_t mean;
-	uint64_t aggregated_variance;
-	unsigned reset;
+	uint64_t 		sum;
+	uint64_t 		count;
+	uint64_t 		min;
+	uint64_t 		max;
+	uint64_t 		last;
+	uint64_t 		mean;
+	uint64_t 		aggregated_variance;
+	struct reset_info 	reset;
 };
 
 

--- a/src/procstat.h
+++ b/src/procstat.h
@@ -343,10 +343,14 @@ int procstat_create_multiple_u64_series(struct procstat_context *context,
  */
 void procstat_u64_series_add_point(struct procstat_series_u64 *series, uint64_t value);
 
+void procstat_u64_series_set_reset_interval(struct procstat_series_u64 *series, int reset_interval);
+
 int procstat_create_histogram_u32_series(struct procstat_context *context, struct procstat_item *parent,
 					 const char *name, struct procstat_histogram_u32 *series);
 
 void procstat_histogram_u32_add_point(struct procstat_histogram_u32 *series, uint32_t value);
+
+void procstat_histogram_u32_series_set_reset_interval(struct procstat_histogram_u32 *series, int reset_interval);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Added control 'reset_interval_sec' for automatic periodic resetting of time-series and histogram values. When set to 0, periodic reset is disabled. Values in seconds.
(LBM1-8581)