### PR TITLE
procstat: support for fuse forget

### DIFF
--- a/src/procstat.c
+++ b/src/procstat.c
@@ -687,6 +687,7 @@ void procstat_remove(struct procstat_context *context, struct procstat_item *ite
 
 remove_item:
 	item->flags &= ~STATS_ENTRY_FLAG_REGISTERED;
+	list_del_init(&item->entry); /* Make it not discoverable */
 	item_put_locked(item);
 done:
 	pthread_mutex_unlock(&context->global_lock);
@@ -712,6 +713,7 @@ int procstat_remove_by_name(struct procstat_context *context,
 		return ENOENT;
 	}
 	item->flags &= ~STATS_ENTRY_FLAG_REGISTERED;
+	list_del_init(&item->entry); /* Make it not discoverable */
 	item_put_locked(item);
 	pthread_mutex_unlock(&context->global_lock);
 	return 0;


### PR DESCRIPTION
Here's the change that resolves the long outstanding crash in fuse_read (use after free).
Description - below.
[libfusedoc](https://github.com/libfuse/libfuse/blob/master/include/fuse_lowlevel.h)

NOTES:
1) per the same doc:
> On unmount the lookup count for all inodes implicitly drop to zero. It is not guaranteed that the file system will receive corresponding forget messages for the affected inodes.
2) I verified that forget() callback is invoked, and items DO get freed.

I don't handle this in any way: we umount on process exit, and freeing all the remaining procstat nodes is IMO not an imperative.

----------------------------

procstat: fuse_lookup refcnt and fuse_forget

fuse_open() takes the ino parameter, which is discovered by caller using fuse_lookup().
There's no guarantee that the item does not get removed between the two, and since after remove the ino points to stale memory, fuse_open()/fuse_read() cannot safely detect this case.

The libfuse documentation explicitly states this and instructs the implementation to:
- refcount the item on fuse_lookup() positive response (fuse_reply_entry)
- implement fuse_forget() that tells to drop the refcnt.

In this commit we do just this.

----------------------------

procstat_remove: make item not discoverable

procstat_remove() will not free_item() if refcnt is not 0.
The items pending free should not be discoverable, in order to the following lookups/readdir calls to see they are removed.
Also, this enables creating new items with the same name, otherwise such attempt would fail (duplicate).

In order to achieve this, adding explicit list_del_init() calls free_item() can still list_del(), which does not make harm.

----------------------------


Issue: LBM1-11658
