### PR TITLE
procstat_stop: new api for safe shutdown

### DIFF
--- a/src/procstat.c
+++ b/src/procstat.c
@@ -1203,6 +1203,17 @@ free_stats:
 	return NULL;
 }
 
+void procstat_stop(struct procstat_context *context)
+{
+	struct fuse_session *session;
+
+	assert(context);
+	session = context->session;
+
+	if (session)
+		fuse_session_exit(session);
+}
+
 void procstat_destroy(struct procstat_context *context)
 {
 	struct fuse_session *session;

--- a/src/procstat.h
+++ b/src/procstat.h
@@ -85,6 +85,11 @@ struct procstat_simple_handle {
 struct procstat_context *procstat_create(const char *mountpoint);
 
 /**
+ * @brief signal the loop to exit
+ */
+void procstat_stop(struct procstat_context *context);
+
+/**
  * @brief unregister and destroy all registered statistics
  */
 void procstat_destroy(struct procstat_context *context);


### PR DESCRIPTION
New procstat_stop() function invokes fuse_session_exit(session);
This triggers fuse_session_loop() to exits.
The caller then can join the thread running fuse_session_loop().
After this it is safe to call procstat_destroy().

Note: procstat_destroy() still calls fuse_session_exit().
It is safe to do so after procstat_stop(),
and enables compatibility with users that do not call procstat_stop().

Issue: LBM1-12042

Signed-off-by: Anton Eidelman <anton@lightbitslabs.com>