### PR TITLE
procstat aggregator

### DIFF
--- a/src/procstat.c
+++ b/src/procstat.c
@@ -880,7 +880,7 @@ static ssize_t series_u64_read(void *object, uint64_t arg, char *buffer, size_t 
 		return -1;
 	}
 write_zero:
-	return snprintf(buffer, len, "0");
+	return snprintf(buffer, len, "0\n");
 write_var:
 	return procstat_format_u64_decimal(data_ptr, arg, buffer, len);
 
@@ -1335,7 +1335,7 @@ static ssize_t histogram_u32_series_read(void *object, uint64_t arg, char *buffe
 		return -1;
 	}
 write_zero:
-	return snprintf(buffer, len, "0");
+	return snprintf(buffer, len, "0\n");
 write_var:
 	return procstat_format_u64_decimal(data_ptr, arg, buffer, len);
 }

--- a/src/procstat.c
+++ b/src/procstat.c
@@ -61,6 +61,8 @@ enum {
 	STATS_ENTRY_FLAG_AGGREGATOR  = 1 << 3,
 };
 
+#define SERIES_RESET_CLOCK CLOCK_MONOTONIC_COARSE
+
 #define ATTRIBUTES_TIMEOUT_SEC (60.0 * 60)
 #define DNAME_INLINE_LEN 32
 struct procstat_dynamic_name {
@@ -1015,7 +1017,7 @@ bool is_reset(struct reset_info* reset)
 	uint64_t reset_interval, time_since_last_reset;
 
 	struct timespec cur_time;
-	if (clock_gettime(CLOCK_REALTIME, &cur_time) == 0) {
+	if (clock_gettime(SERIES_RESET_CLOCK, &cur_time) == 0) {
 		time_since_last_reset = cur_time.tv_sec - reset->last_reset_time;
 		reset_interval = __atomic_load_n(&reset->reset_interval, __ATOMIC_RELAXED);
 		if ((reset_interval) && (time_since_last_reset > reset_interval)) {
@@ -1226,7 +1228,7 @@ int procstat_create_u64_series(struct procstat_context *context, struct procstat
 	}
 
 	struct timespec cur_time;
-	if (clock_gettime(CLOCK_REALTIME, &cur_time) == 0) {
+	if (clock_gettime(SERIES_RESET_CLOCK, &cur_time) == 0) {
 		series->reset.last_reset_time = cur_time.tv_sec;
 	} else {
 		series->reset.last_reset_time = 0;
@@ -1696,7 +1698,7 @@ int procstat_create_histogram_u32_series(struct procstat_context *context, struc
 	}
 
 	struct timespec cur_time;
-	if (clock_gettime(CLOCK_REALTIME, &cur_time) == 0) {
+	if (clock_gettime(SERIES_RESET_CLOCK, &cur_time) == 0) {
 		series->reset.last_reset_time = cur_time.tv_sec;
 	} else {
 		series->reset.last_reset_time = 0;

--- a/src/procstat.c
+++ b/src/procstat.c
@@ -528,6 +528,9 @@ static int out_item(struct out_stream *out, char *path, struct procstat_item *it
 		total += len > space ? space : len;
 		if (len > space)
 			return -1;
+		if (len == space)
+			/* exact fit: snprintf clobbers the last char (\n) with a 0: restore it */
+			out->buf[total - 1] = '\n';
 		/* Now the line is fully generated */
 		out->total = total;
 		++out->lines;

--- a/src/procstat.c
+++ b/src/procstat.c
@@ -380,6 +380,8 @@ static void fuse_readdir(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
 
 		if (!item_registered(iter))
 			continue;
+		if (iter->flags & STATS_ENTRY_FLAG_AGGREGATOR)
+			continue;
 		memset(&stat, 0, sizeof(stat));
 		fname = procstat_item_name(iter);
 		fill_item_stats(context, iter, &stat);

--- a/src/procstat.h
+++ b/src/procstat.h
@@ -154,6 +154,13 @@ int procstat_create_simple(struct procstat_context *context,
 			   struct procstat_simple_handle *descriptors,
 			   size_t descriptors_len);
 
+/**
+ * @brief creates a file that on read outputs the contents of the entire directory tree.
+ * @return 0 on success, -1  in case of failure and errno will be set accordingly
+ */
+int procstat_create_aggregator(struct procstat_context *context,
+			   struct procstat_item *parent,
+			   const char *name);
 
 
 #define DEFINE_PROCSTAT_FORMATTER(__type, __fmt, __fmt_name)\


### PR DESCRIPTION
Adding support for aggregator nodes.
Adding such a node is done by means of procstat_create_aggregator().
The node is a file that enables reading the full contents of the directory containing it, including all sub-directories)
The output format is currently identical to output of

> cd dir; grep -r "" --exclude=aggregator_file_name

See the corresponding duroslight [PR](https://github.com/LightBitsLabs/duroslight/pull/1006)

Issue: LBM1-15406