### PR TITLE
lookup without holding the lock during registration

### DIFF
--- a/src/procstat.c
+++ b/src/procstat.c
@@ -54,6 +54,14 @@
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof(*a))
 #endif
 
+#ifndef unlikely
+#define unlikely(x)     __builtin_expect(!!(x), 0)
+#endif
+
+#ifndef likely
+#define likely(x)       __builtin_expect(!!(x), 1)
+#endif
+
 enum {
 	STATS_ENTRY_FLAG_REGISTERED  = 1 << 0,
 	STATS_ENTRY_FLAG_DIR	     = 1 << 1,


### PR DESCRIPTION
global_lock is a source of contention when multiple threads/cores
are adding stats concurrently, e.g. when a volume is being created
so every core has to create a set of volume stats.

This contention is mostly redundant as every directory in the root
and the entire sub-tree under it is only modified by the core
that owns it.

While a better solution would be to have a separate lock for each
of these sub-trees, we can reduce the contention by holding the lock
for a shorter period of time.
One of the suspected long locked periods is lookup for duplicate
entry done in register_item(): this walks the list, which is O(N)
and can be expensive for the "namespaces" directory with 10K entries.

Based on the above, we lookup for duplicates without holding a lock,
unless looking up in the root directory.

List modification as well as item initialization is still done under lock
to make sure the fuse interface always finds the directory and the
item in a consistent state.

Issue: LBM1-19873
Issue: LBM1-20016
