### PR TITLE
Procstat build: support compilation in lbv2 build system.

### DIFF
--- a/Makefile.container
+++ b/Makefile.container
@@ -1,0 +1,19 @@
+include $(WORKSPACE_TOP)/common/Makefile.env
+
+all: build
+
+LBGO_CONTAINER_VERSION = $(shell component-tool version --repo=lb_containers --type=$(BUILD_TYPE) lbcpp)
+
+build:
+	run_in_container -i lbcpp:${LBGO_CONTAINER_VERSION} -- ${MAKE} -f Makefile.lb $@
+
+install:
+	run_in_container -i lbcpp:latest -- ${MAKE} -f Makefile.lb $@
+
+checkin:
+	run_in_container -i lbcpp:latest -- ${MAKE} -f Makefile.lb $@
+
+clean:
+	run_in_container -i lbcpp:latest -- ${MAKE} -f Makefile.lb $@
+
+.PHONY: clean checkin build

--- a/lbv2.yaml
+++ b/lbv2.yaml
@@ -1,0 +1,8 @@
+procstat:
+  procstat:
+    build:
+      - make -f Makefile.container all
+    install:
+      - make -f Makefile.container install
+    deps:
+    - file://src


### PR DESCRIPTION
1. Use specific container for compiling Procstat without being depend on dockerize.
2. Add lbv2 for lbyaml v2 support.

This change coexist with current build system (dockerize and lb-build)
https://github.com/LightBitsLabs/common/pull/3591