### PR TITLE
procstat: expose an interface to reset u64/histogram

### DIFF
--- a/src/procstat.c
+++ b/src/procstat.c
@@ -1118,6 +1118,11 @@ bool is_reset(struct reset_info* reset)
 	}
 }
 
+int procstat_u64_needs_reset(struct procstat_series_u64 *series)
+{
+	return is_reset(&series->reset);
+}
+
 void clear_values_series(struct procstat_series_u64 *series)
 {
 	series->count = 0;
@@ -1812,6 +1817,11 @@ fail_remove_stat:
 void procstat_histogram_u32_series_set_reset_interval(struct procstat_histogram_u32 *series, int reset_interval)
 {
 	series->reset.reset_interval = reset_interval;
+}
+
+int procstat_histogram_u32_needs_reset(struct procstat_histogram_u32 *series)
+{
+	return is_reset(&series->reset);
 }
 
 struct procstat_item *procstat_lookup_item(struct procstat_context *context,

--- a/src/procstat.h
+++ b/src/procstat.h
@@ -357,12 +357,16 @@ void procstat_u64_series_add_point(struct procstat_series_u64 *series, uint64_t 
 
 void procstat_u64_series_set_reset_interval(struct procstat_series_u64 *series, int reset_interval);
 
+int procstat_u64_needs_reset(struct procstat_series_u64 *series);
+
 int procstat_create_histogram_u32_series(struct procstat_context *context, struct procstat_item *parent,
 					 const char *name, struct procstat_histogram_u32 *series);
 
 void procstat_histogram_u32_add_point(struct procstat_histogram_u32 *series, uint32_t value);
 
 void procstat_histogram_u32_series_set_reset_interval(struct procstat_histogram_u32 *series, int reset_interval);
+
+int procstat_histogram_u32_needs_reset(struct procstat_histogram_u32 *series);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Consumers that may consume procstat beyond the fuse interface may also need to reset the stats, expose an interface for it.